### PR TITLE
chore: change git url dep to npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/ovvn/dom-to-pdf"
   },
   "dependencies": {
-    "dom-to-image": "https://github.com/dmapper/dom-to-image",
+    "@zhiyuc123/dom-to-image": "^2.6.0",
     "jspdf": "^2.5.1"
   },
   "keywords": [


### PR DESCRIPTION
Use github url as a dependecy may not be available in intranet environment.

[@zhiyuc123/dom-to-image](https://www.npmjs.com/package/@zhiyuc123/dom-to-image) is a fork of https://github.com/dmapper/dom-to-image which was published to npm registry.